### PR TITLE
Adding PEP8 github actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+name: Code style - PEP8
+
+on: [push, pull_request]
+
+jobs:
+
+  flake8-lint:
+    runs-on: ubuntu-latest
+    name: Lint
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v2
+      - name: Set up Python environment
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: flake8 Lint
+        uses: py-actions/flake8@v2

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # srlite
+
+![Code style: PEP8](https://github.com/nasa-cisto-ai/tensorflow-caney/actions/workflows/lint.yml/badge.svg)
+
 surface reflectance


### PR DESCRIPTION
Hi Glenn, Added Github actions to the repository for PEP8 checking (just a simple check so you have it). A badge will prompt stating if it fails or succeeds based on PEP8 standards. Just a proof of concept for some automated CI/CD that can be done. Feel free to approve this pull request and changes will populate. The only change once merged, is to change the path of the badge from the README file to match the one from the repository (replace nasa-cisto-ai with nasa-nccs-hpda)